### PR TITLE
Added types for user statements.

### DIFF
--- a/src/interfaces/statement.ts
+++ b/src/interfaces/statement.ts
@@ -1,0 +1,69 @@
+export interface IGetStatementsApiResponse {
+  error_code: string;
+  http_code: string;
+  limit: number;
+  page: number;
+  page_count: number;
+  statements_count: number;
+  statements: (IStatementObject|IInterestIncome1099)[],
+  success: boolean;
+}
+
+/**
+ * {@link [Statement Object Details](https://docs.synapsefi.com/api-references/statements/statement-object-details)}
+ */
+export interface IStatementObject {
+  _id: string;
+  client: {
+    id: string;
+    name: string;
+    user_id: string;
+  };
+  date_end: number;
+  date_start: number;
+  end_date: number;
+  ending_balance: number;
+  is_fee_node: boolean;
+  node: IStatementNode;
+  node_id: string;
+  opening_balance: number;
+  start_date: number;
+  subnet: IStatementSubnet;
+  type: string;
+  urls: {
+    csv: string;
+    json: string;
+    pdf: string;
+  };
+  user_id: string;
+  user_name: string;
+}
+
+export interface IStatementNode {
+  created_on: number;
+  currency: string;
+  nickname: string;
+  type: string;
+}
+
+export interface IStatementSubnet {
+  account_num: string;
+  ach: string;
+  has_subnet: boolean;
+  wire: string;
+}
+
+
+/**
+ * {@link [Undocumented Object Details, but referenced in the 'type' property](https://docs.synapsefi.com/api-references/statements/statement-object-details)}
+ */
+export interface IInterestIncome1099 {
+  _id: string;
+  client_id: string;
+  date_end: number;
+  date_start: number;
+  link: string;
+  node_id: string;
+  type: string;
+  user_id: string;
+}

--- a/src/lib/User.ts
+++ b/src/lib/User.ts
@@ -7,6 +7,7 @@ import { IUserObject } from "../interfaces/user";
 import { IgenECashBarcodePayload, IGetNodesApiResponse, INodeDetailsObject } from "../interfaces/node";
 import { IDisputeTransactionPayload, IGetTransactionsApiResponse, ITransactionDetailsObject } from "../interfaces/transaction";
 import { IGetShipmentsApiResponse, IGetSubnetsApiResponse, IShipmentObject, ISubnetDetailsObject } from "../interfaces/subnet";
+import { IGetStatementsApiResponse } from "../interfaces/statement";
 
 class User {
   id: string;
@@ -329,7 +330,7 @@ class User {
    */
   getStatementsByUser(
     queryParams: IQueryParams = {}
-  ): Promise<AxiosResponse<any>> {
+  ): Promise<AxiosResponse<IGetStatementsApiResponse>> {
     const { page, per_page } = queryParams;
     const { host, headers, id } = this;
     const originalUrl = `${host}/users/${id}/statements`;
@@ -354,7 +355,7 @@ class User {
   getStatementsByNode(
     node_id: string,
     queryParams: IQueryParams = {}
-  ): Promise<AxiosResponse<any>> {
+  ): Promise<AxiosResponse<IGetStatementsApiResponse>> {
     const { page, per_page } = queryParams;
     const { host, headers, id } = this;
     const originalUrl = `${host}/users/${id}/nodes/${node_id}/statements`;

--- a/types/interfaces/statement.d.ts
+++ b/types/interfaces/statement.d.ts
@@ -1,0 +1,64 @@
+export interface IGetStatementsApiResponse {
+    error_code: string;
+    http_code: string;
+    limit: number;
+    page: number;
+    page_count: number;
+    statements_count: number;
+    statements: (IStatementObject | IInterestIncome1099)[];
+    success: boolean;
+}
+/**
+ * {@link [Statement Object Details](https://docs.synapsefi.com/api-references/statements/statement-object-details)}
+ */
+export interface IStatementObject {
+    _id: string;
+    client: {
+        id: string;
+        name: string;
+        user_id: string;
+    };
+    date_end: number;
+    date_start: number;
+    end_date: number;
+    ending_balance: number;
+    is_fee_node: boolean;
+    node: IStatementNode;
+    node_id: string;
+    opening_balance: number;
+    start_date: number;
+    subnet: IStatementSubnet;
+    type: string;
+    urls: {
+        csv: string;
+        json: string;
+        pdf: string;
+    };
+    user_id: string;
+    user_name: string;
+}
+export interface IStatementNode {
+    created_on: number;
+    currency: string;
+    nickname: string;
+    type: string;
+}
+export interface IStatementSubnet {
+    account_num: string;
+    ach: string;
+    has_subnet: boolean;
+    wire: string;
+}
+/**
+ * {@link [Undocumented Object Details, but referenced in the 'type' property](https://docs.synapsefi.com/api-references/statements/statement-object-details)}
+ */
+export interface IInterestIncome1099 {
+    _id: string;
+    client_id: string;
+    date_end: number;
+    date_start: number;
+    link: string;
+    node_id: string;
+    type: string;
+    user_id: string;
+}

--- a/types/lib/User.d.ts
+++ b/types/lib/User.d.ts
@@ -5,6 +5,7 @@ import { IUserObject } from "../interfaces/user";
 import { IgenECashBarcodePayload, IGetNodesApiResponse, INodeDetailsObject } from "../interfaces/node";
 import { IDisputeTransactionPayload, IGetTransactionsApiResponse, ITransactionDetailsObject } from "../interfaces/transaction";
 import { IGetShipmentsApiResponse, IGetSubnetsApiResponse, IShipmentObject, ISubnetDetailsObject } from "../interfaces/subnet";
+import { IGetStatementsApiResponse } from "../interfaces/statement";
 declare class User {
     id: string;
     body: IUserObject;
@@ -126,7 +127,7 @@ declare class User {
      * {@link [Statement Object Details](https://docs.synapsefi.com/api-references/statements/statement-object-details)}
      * {@link [View all user statements](https://docs.synapsefi.com/api-references/statements/view-all-user-statements)}
      */
-    getStatementsByUser(queryParams?: IQueryParams): Promise<AxiosResponse<any>>;
+    getStatementsByUser(queryParams?: IQueryParams): Promise<AxiosResponse<IGetStatementsApiResponse>>;
     /**
      * @description gets list of statement objects base on passed node id
      * @param queryParams
@@ -135,7 +136,7 @@ declare class User {
      * {@link [Statement Object Details](https://docs.synapsefi.com/api-references/statements/statement-object-details)}
      * {@link [View all node statements](https://docs.synapsefi.com/api-references/statements/view-all-node-statements)}
      */
-    getStatementsByNode(node_id: string, queryParams?: IQueryParams): Promise<AxiosResponse<any>>;
+    getStatementsByNode(node_id: string, queryParams?: IQueryParams): Promise<AxiosResponse<IGetStatementsApiResponse>>;
     /**
      * @deprecated use `shipCard` instead
      */


### PR DESCRIPTION
Thank You, swizzard, for making these SynapseNode types available.  In appreciation, I contribute "statement" types to the list. Note: "1099 Interest Income Tax Forms" are returned alongside "Monthly Statements".  The only way to determine which  is which is by looking at the value of the "type" field ("NOV_2022_STATEMENT" vs "1099_INT_2022" as examples). The documentation vaguely references an "ONDEMAND_STATEMENT", but I am unable to find details for it. The details for the monthly statements and 1099 Interest Income forms are both provided by looking at data returned from a production account.